### PR TITLE
Form Container

### DIFF
--- a/src/Components/Color/Color.js
+++ b/src/Components/Color/Color.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import './Color.scss';
+
+export const Color = (props) => {
+  return (
+    <span className='color-div' style={{backgroundColor: `#${props.color}`}}>
+    </span>
+  )
+}
+
+export default Color;

--- a/src/Components/Color/Color.scss
+++ b/src/Components/Color/Color.scss
@@ -1,0 +1,7 @@
+
+
+.color-div {
+  height: 5em;
+  width: 5em;
+}
+

--- a/src/Components/Color/Color.scss
+++ b/src/Components/Color/Color.scss
@@ -1,5 +1,3 @@
-
-
 .color-div {
   height: 5em;
   width: 5em;

--- a/src/Components/FormContainer/FormContainer.js
+++ b/src/Components/FormContainer/FormContainer.js
@@ -6,10 +6,10 @@ import PaletteForm from '../PaletteForm/PaletteForm';
 
 export const FormContainer = () => {
   return (
-    <> 
-      <ProjectForm />
-      <PaletteForm />
-    </>
+      <article className="main-box"> 
+        <ProjectForm />
+        <PaletteForm />
+      </article>
   )
 }
 

--- a/src/Components/FormContainer/FormContainer.js
+++ b/src/Components/FormContainer/FormContainer.js
@@ -5,10 +5,10 @@ import PaletteForm from '../PaletteForm/PaletteForm'
 
 export const FormContainer = () => {
   return (
-    <> 
-      <ProjectForm />
-      <PaletteForm />
-    </>
+      <article className="main-box"> 
+        <ProjectForm />
+        <PaletteForm />
+      </article>
   )
 }
 

--- a/src/Components/FormContainer/FormContainer.scss
+++ b/src/Components/FormContainer/FormContainer.scss
@@ -1,0 +1,9 @@
+@import '../../scss/variables';
+
+.main-box {
+  border-radius: 30px;
+  background-color: $background-neutral-color;
+  width: 60%;
+  margin: 0 auto;
+  padding: 2em;
+}

--- a/src/Components/Palette/Palette.js
+++ b/src/Components/Palette/Palette.js
@@ -1,12 +1,31 @@
 import React from 'react';
 import './Palette.scss';
+import Color from '../Color/Color';
 
 export const Palette = () => {
+  const colors = ['000000', 'ffffff', '000000', 'ffffff', '000000']
+  const generatePalette = colors.map(color => {
+    return (
+      <>
+        <Color
+          key={color} 
+          color={color}
+        />
+      </>
+    )
+  })
+
   return (
-    <> 
-      This is a palette!
-    </>
+    <aside className="palette-wrapper">
+      <button className="delete-button">X</button>
+      <div className="palettes-wrapper">
+        {generatePalette}
+      </div>
+      <h4 className="palette-name-label">Palette Name</h4>
+    </aside>
   )
 }
 
 export default Palette;
+
+//mapState to GET the palettes for a given project 

--- a/src/Components/Palette/Palette.scss
+++ b/src/Components/Palette/Palette.scss
@@ -12,6 +12,8 @@
   border: none;
     &:hover {
       cursor: pointer;
+      transform: scale(1.06);
+      font-weight: bold;
     }
 }
 

--- a/src/Components/Palette/Palette.scss
+++ b/src/Components/Palette/Palette.scss
@@ -19,4 +19,5 @@
   font-family: $accent-font;
   font-size: 2em;
   padding-left: 0px;
+  font-weight: lighter;
 }

--- a/src/Components/Palette/Palette.scss
+++ b/src/Components/Palette/Palette.scss
@@ -1,0 +1,22 @@
+@import '../../scss/variables';
+
+.palette-wrapper {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.delete-button {
+  font-size: 2em;
+  background-color: $background-neutral-color;
+  border: none;
+    &:hover {
+      cursor: pointer;
+    }
+}
+
+.palette-name-label {
+  font-family: $accent-font;
+  font-size: 2em;
+  padding-left: 0px;
+}

--- a/src/Components/PaletteForm/PaletteForm.js
+++ b/src/Components/PaletteForm/PaletteForm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import './PaletteForm.scss';
 import Color from '../Color/Color'
+import PalettesContainer from '../PalettesContainer/PalettesContainer';
 
 export const PaletteForm = () => {
   const colors = ['000000', 'ffffff', '000000', 'ffffff', '000000']
@@ -17,13 +18,21 @@ export const PaletteForm = () => {
 
   return (
     <form className="add-palette-form">
-      <div className="name-palette-wrapper">
-        <label className="name-palette-label">NAME PALETTE</label>
-        <input className="name-palette-input" type="text"></input>
+
+
+      <div className="add-palette-form-top">
+        <div className="name-palette-wrapper">
+          <label className="name-palette-label">NAME PALETTE</label>
+          <input className="name-palette-input" type="text"></input>
+        </div>
+        <div className="palettes-wrapper">
+          {generatePalette}
+        </div>
+
       </div>
-      <div className="palettes-wrapper">
-        {generatePalette}
-      </div>
+
+      <button className="add-palette-button" type="button">add to project</button>
+      <PalettesContainer />
     </form>
   )
 }

--- a/src/Components/PaletteForm/PaletteForm.js
+++ b/src/Components/PaletteForm/PaletteForm.js
@@ -22,7 +22,7 @@ export const PaletteForm = () => {
 
       <div className="add-palette-form-top">
         <div className="name-palette-wrapper">
-          <label className="name-palette-label">NAME PALETTE</label>
+          <label className="name-palette-label">PALETTE NAME</label>
           <input className="name-palette-input" type="text"></input>
         </div>
         <div className="palettes-wrapper">

--- a/src/Components/PaletteForm/PaletteForm.js
+++ b/src/Components/PaletteForm/PaletteForm.js
@@ -1,12 +1,35 @@
 import React from 'react';
 import './PaletteForm.scss';
+import Color from '../Color/Color'
 
 export const PaletteForm = () => {
+  const colors = ['000000', 'ffffff', '000000', 'ffffff', '000000']
+  const generatePalette = colors.map(color => {
+    return (
+      <>
+        <Color
+          key={color} 
+          color={color}
+        />
+      </>
+    )
+  })
+
   return (
-    <> 
-      this is the palette form!
-    </>
+    <form className="add-palette-form">
+      <div className="name-palette-wrapper">
+        <label className="name-palette-label">NAME PALETTE</label>
+        <input className="name-palette-input" type="text"></input>
+      </div>
+      <div className="palettes-wrapper">
+        {generatePalette}
+      </div>
+    </form>
   )
 }
 
 export default PaletteForm;
+
+
+//props will hold 5 random colors from ProjectForm's generate colors 
+//add to project button will fire POST request, re-render new PaletteForm

--- a/src/Components/PaletteForm/PaletteForm.scss
+++ b/src/Components/PaletteForm/PaletteForm.scss
@@ -6,13 +6,16 @@
   margin: 1em;
 }
 
+.name-palette-wrapper {
+  text-align: left;
+}
+
 .name-palette-input {
   font-size: 1.25em;
-  padding: .25em;
   font-family: $main-font;
 }
 
-.add-palette-form {
+.add-palette-form-top {
   display: flex;
   justify-content: space-around;
   align-items: center;
@@ -21,4 +24,20 @@
 .palettes-wrapper {
   display: flex;
   flex-direction: row;
+}
+
+.add-palette-button {
+  display: block;
+  background-color: $accent-color;
+  font-family: $accent-font;
+  color: $light-font-color;
+  font-size: 3em;
+  border-radius: 20px;
+  padding: .25em;
+    &:hover {
+      background-color: $hover-accent-color;
+      cursor: pointer;
+      transform: scale(1.03);
+    }
+  margin: 1em auto;
 }

--- a/src/Components/PaletteForm/PaletteForm.scss
+++ b/src/Components/PaletteForm/PaletteForm.scss
@@ -1,0 +1,24 @@
+@import '../../scss/variables';
+
+.name-palette-label {
+  font-family: $main-font;
+  font-size: 1.5em;
+  margin: 1em;
+}
+
+.name-palette-input {
+  font-size: 1.25em;
+  padding: .25em;
+  font-family: $main-font;
+}
+
+.add-palette-form {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.palettes-wrapper {
+  display: flex;
+  flex-direction: row;
+}

--- a/src/Components/PalettesContainer/PalettesContainer.js
+++ b/src/Components/PalettesContainer/PalettesContainer.js
@@ -4,9 +4,10 @@ import Palette from '../Palette/Palette';
 
 export const PalettesContainer = () => {
   return (
-    <> 
+    <div className="palettes-container"> 
+      <h3 className="palettes-title">PALETTES</h3>
       <Palette />
-    </>
+    </div>
   )
 }
 

--- a/src/Components/PalettesContainer/PalettesContainer.js
+++ b/src/Components/PalettesContainer/PalettesContainer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import './FormContainer.scss';
+import './PalettesContainer.scss';
 import Palette from '../Palette/Palette';
 
 export const PalettesContainer = () => {

--- a/src/Components/PalettesContainer/PalettesContainer.scss
+++ b/src/Components/PalettesContainer/PalettesContainer.scss
@@ -1,0 +1,13 @@
+@import '../../scss/variables';
+
+.palettes-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.palettes-title {
+  font-family: $main-font;
+  font-size: 2em;
+  margin: 0px auto;
+  font-weight: lighter;
+}

--- a/src/Components/ProjectForm/ProjectForm.js
+++ b/src/Components/ProjectForm/ProjectForm.js
@@ -12,7 +12,7 @@ export const ProjectForm = (props) => {
     event.preventDefault();
     try {
       const response = await postProject(title)
-      dispatch(addProject(response.id, title))
+      dispatch(addProject(response.id[0], title))
     } catch (error) {
       console.log(error)
     }

--- a/src/Components/ProjectForm/ProjectForm.js
+++ b/src/Components/ProjectForm/ProjectForm.js
@@ -18,16 +18,17 @@ export const ProjectForm = (props) => {
 
         <button className="generate-palette-button" type="button">generate palette</button>
       </form>
-
     </div>
   )
 }
 
-export const mapStateToProps = state => ({
+// export const mapStateToProps = state => ({
 
-})
+// })
 
 export default ProjectForm;
 
 // regular props, passed down from clickevent from sidebar - show the project title 
 // mapDispatchToProps - create new project, rerender App so it shows up in the sidebar, also shows up on the main card 
+
+//when click generate palette - generate 5 random colors, pass those down to PaletteForm component 

--- a/src/Components/ProjectForm/ProjectForm.js
+++ b/src/Components/ProjectForm/ProjectForm.js
@@ -1,12 +1,32 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import './ProjectForm.scss';
+import { postProject } from '../../util/apiCalls';
+import { addProject } from '../../actions/actions';
 
 export const ProjectForm = (props) => {
-  const projectTitle = props.valueOf();
+  const [title, setTitle] = useState("");
+  const dispatch = useDispatch();
 
 
+  //re-render to show title (mapState) -- useEvent but listens for the generate palette button click?
+
+  useEffect(() => {
+    //mapState to set title = what's in store 
+  }, [dispatch])
 
 
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      const response = await postProject(title)
+      // const project = await response.json();
+      dispatch(addProject(response.id, title))
+    } catch (error) {
+      console.log(error)
+    }
+    //generate 5 random colors and render paletteForm component 
+  }
 
   return (
     <div className="project-form-wrapper"> 
@@ -14,21 +34,13 @@ export const ProjectForm = (props) => {
         {/* <h2 className="project-name-main"></h2> */}
 
           <label className="title-input-label">PROJECT TITLE</label>
-          <input className="title-input" type="text" /> 
+          <input className="title-input" type="text" onChange={(event) => setTitle(event.target.value)}/> 
 
-        <button className="generate-palette-button" type="button">generate palette</button>
+        <button className="generate-palette-button" type="button" onClick={(event) => handleSubmit(event)}>generate palette</button>
       </form>
     </div>
   )
 }
 
-// export const mapStateToProps = state => ({
-
-// })
 
 export default ProjectForm;
-
-// regular props, passed down from clickevent from sidebar - show the project title 
-// mapDispatchToProps - create new project, rerender App so it shows up in the sidebar, also shows up on the main card 
-
-//when click generate palette - generate 5 random colors, pass those down to PaletteForm component 

--- a/src/Components/ProjectForm/ProjectForm.js
+++ b/src/Components/ProjectForm/ProjectForm.js
@@ -1,12 +1,33 @@
 import React from 'react';
 import './ProjectForm.scss';
 
-export const ProjectForm = () => {
+export const ProjectForm = (props) => {
+  const projectTitle = props.valueOf();
+
+
+
+
+
   return (
-    <> 
-      this is the project form!
-    </>
+    <div className="project-form-wrapper"> 
+      <form className="project-name-form">
+        {/* <h2 className="project-name-main"></h2> */}
+
+          <label className="title-input-label">PROJECT TITLE</label>
+          <input className="title-input" type="text" /> 
+
+        <button className="generate-palette-button" type="button">generate palette</button>
+      </form>
+
+    </div>
   )
 }
 
+export const mapStateToProps = state => ({
+
+})
+
 export default ProjectForm;
+
+// regular props, passed down from clickevent from sidebar - show the project title 
+// mapDispatchToProps - create new project, rerender App so it shows up in the sidebar, also shows up on the main card 

--- a/src/Components/ProjectForm/ProjectForm.js
+++ b/src/Components/ProjectForm/ProjectForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useSelector } from 'react';
 import { useDispatch } from 'react-redux';
 import './ProjectForm.scss';
 import { postProject } from '../../util/apiCalls';
@@ -8,31 +8,19 @@ export const ProjectForm = (props) => {
   const [title, setTitle] = useState("");
   const dispatch = useDispatch();
 
-
-  //re-render to show title (mapState) -- useEvent but listens for the generate palette button click?
-
-  useEffect(() => {
-    //mapState to set title = what's in store 
-  }, [dispatch])
-
-
   const handleSubmit = async (event) => {
     event.preventDefault();
     try {
       const response = await postProject(title)
-      // const project = await response.json();
       dispatch(addProject(response.id, title))
     } catch (error) {
       console.log(error)
     }
-    //generate 5 random colors and render paletteForm component 
   }
 
   return (
     <div className="project-form-wrapper"> 
       <form className="project-name-form">
-        {/* <h2 className="project-name-main"></h2> */}
-
           <label className="title-input-label">PROJECT TITLE</label>
           <input className="title-input" type="text" onChange={(event) => setTitle(event.target.value)}/> 
 

--- a/src/Components/ProjectForm/ProjectForm.scss
+++ b/src/Components/ProjectForm/ProjectForm.scss
@@ -1,0 +1,34 @@
+@import '../../scss/variables';
+
+
+.project-form-wrapper {
+  text-align: center;
+}
+.title-input-label {
+  font-size: 2em;
+  font-family: $main-font;
+}
+
+.title-input {
+  font-size: 1.5em;
+  margin: 0em 2em;
+  padding: .25em;
+  font-family: $main-font;
+}
+
+.generate-palette-button {
+  display: block;
+  background-color: $accent-color;
+  font-family: $accent-font;
+  color: $light-font-color;
+  font-size: 3em;
+  border-radius: 20px;
+  padding: .25em;
+    &:hover {
+      background-color: $hover-accent-color;
+      cursor: pointer;
+      transform: scale(1.03);
+    }
+  margin: 1em auto;
+}
+

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -1,0 +1,7 @@
+export const addProject = (id, title) => ({
+  type: 'ADD_PROJECT',
+  project: {
+    id, 
+    title
+  }
+})

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,13 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import rootReducer from './reducers/reducers';
 
 
-// const store = createStore(rootReducer, composeWithDevTools());
+const store = createStore(rootReducer, composeWithDevTools());
 
-// ReactDOM.render(
-//   <Provider store={store} >
-//     <App />
-//   </Provider>, 
-//   document.getElementById('root')
-// );
+ReactDOM.render(
+  <Provider store={store} >
+    <App />
+  </Provider>, 
+  document.getElementById('root')
+);
 
-
-ReactDOM.render(<App />, document.getElementById('root'));
+serviceWorker.unregister();

--- a/src/reducers/project.js
+++ b/src/reducers/project.js
@@ -1,0 +1,8 @@
+export const project = (state = [], action) => {
+  switch (action.type) {
+    case 'ADD_PROJECT': 
+      return [...state, action.project]
+    default: 
+      return state
+  }
+}

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -2,7 +2,7 @@ export const projects = (state = [], action) => {
     switch (action.type) {
     case 'ADD_PROJECTS':
         return [...state, ...action.projects]
-    case 'ADD_PROEJCT':
+    case 'ADD_PROJECT':
         return [...state, action.project]
     default:
         return state

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -2,6 +2,8 @@ export const projects = (state = [], action) => {
     switch (action.type) {
     case 'ADD_PROJECTS':
         return [...state, ...action.projects]
+    case 'ADD_PROEJCT':
+        return [...state, action.project]
     default:
         return state
     }

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -3,6 +3,7 @@ export const projects = (state = [], action) => {
     case 'ADD_PROJECTS':
         return [...state, ...action.projects]
     case 'ADD_PROJECT':
+        console.log(action.project)
         return [...state, action.project]
     default:
         return state

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -1,10 +1,8 @@
 import { combineReducers } from 'redux';
 import { projects } from './projects';
-import { project } from './project';
 
 const rootReducer = combineReducers({
     projects,
-    projects: project
 })
 
 export default rootReducer;

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
-import { projects } from '../reducers/projects';
+import { projects } from './projects';
+import { project } from './project';
 
 const rootReducer = combineReducers({
-    projects
+    projects,
+    projects: project
 })
 
 export default rootReducer;

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -1,7 +1,8 @@
 import { combineReducers } from 'redux';
+import { project } from './project';
 
 const rootReducer = combineReducers({
-
+  projects: project
 })
 
 export default rootReducer;

--- a/src/util/apiCalls.js
+++ b/src/util/apiCalls.js
@@ -1,0 +1,19 @@
+export const retrieveProjects = async () => {
+  const url = `https://mysterious-dusk-17585.herokuapp.com/api/v1/projects`;
+  const response = await fetch(url);
+  const projects = response.json();
+  if (!response.ok) {
+    throw Error('Error fetching projects');
+  }
+  return projects;
+} 
+
+export const postProject = async (projectTitle) => {
+  const url = `https://mysterious-dusk-17585.herokuapp.com/api/v1/projects`;
+  const response = await fetch(url);
+  const project = response.json();
+  if (!response.ok) {
+    throw Error('Error posting project');
+  }
+  return project;
+}

--- a/src/util/apiCalls.js
+++ b/src/util/apiCalls.js
@@ -8,12 +8,18 @@ export const retrieveProjects = async () => {
   return projects;
 } 
 
-export const postProject = async (projectTitle) => {
-  const url = `https://mysterious-dusk-17585.herokuapp.com/api/v1/projects`;
-  const response = await fetch(url);
-  const project = response.json();
+export const postProject = async projectTitle => {
+  const options = {
+    method: 'POST',
+    body: JSON.stringify({title: projectTitle}),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  };
+
+  const response = await fetch('https://mysterious-dusk-17585.herokuapp.com/api/v1/projects', options);
   if (!response.ok) {
     throw Error('Error posting project');
   }
-  return project;
+  return response.json();
 }

--- a/src/util/apiCalls.js
+++ b/src/util/apiCalls.js
@@ -1,9 +1,19 @@
 export const retrieveProjects = async () => {
-      const url = `https://mysterious-dusk-17585.herokuapp.com/api/v1/projects`;
-      const response = await fetch(url);
-      const projects = response.json();
-      if (!response.ok) {
-        throw Error('Error fetching projects');
-      }
-      return projects;
+  const url = `https://mysterious-dusk-17585.herokuapp.com/api/v1/projects`;
+  const response = await fetch(url);
+  const projects = response.json();
+  if (!response.ok) {
+    throw Error('Error fetching projects');
   }
+  return projects;
+} 
+
+export const postProject = async (projectTitle) => {
+  const url = `https://mysterious-dusk-17585.herokuapp.com/api/v1/projects`;
+  const response = await fetch(url);
+  const project = response.json();
+  if (!response.ok) {
+    throw Error('Error posting project');
+  }
+  return project;
+}


### PR DESCRIPTION
### What's this PR do?

- Render Form Container, which also holds the ProjectContainer, PaletteContainer, and any relevant palettes for that project.
- Adds basic styling to above components
- Connects ProjectContainer to redux store (using Hooks!)
- Successfully does POST request for a new project when user clicks "generate palette"

### Where should the reviewer start?
Pull the branch down and run npm start.  You'll see the styling for the form and can do a POST request by typing in a project name and clicking "generate palette"

### Any background context you want to provide?
Currently, the new project is showing up in the Sidebar, which is great.  We can make it a stretch goal to automatically re-render the ProjectForm to show the project title.  This was originally a goal that I had, but I'm going to take a break from it and move onto other functionality, as this doesn't seem like a necessary thing for an MVP.

The "generate palette" button is also going to need to actually generate a palette (I'm thinking it could render the entire next PaletteForm component), meaning that the PaletteForm wouldn't automatically show up on pageload.

### Screenshots
![Screen Shot 2020-02-09 at 2 22 48 PM](https://user-images.githubusercontent.com/46874658/74110203-b898bc00-4b47-11ea-97f1-8269a939f769.png)

